### PR TITLE
chore: upgrade to Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/ZeroGachis/traefik-magic-jwt
 
-go 1.16
+go 1.22
+


### PR DESCRIPTION
To prepare update Traefik v3 